### PR TITLE
Add dynamic date-token support for folder paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ BRAT will automatically keep the plugin updated.
 | Time range | Last 30 days | How far back to look for meetings |
 | Sync frequency | Every 15 minutes | How often to sync. Options: Manual only, On startup, 1m, 15m, 30m, 60m, 12h |
 | Sync transcripts | Off | Include full meeting transcripts (1 extra API call per meeting) |
-| Folder path | `Meetings` | Where to save meeting notes |
+| Folder path | `Meetings` | Where to save meeting notes. Supports date tokens: `{yyyy}`, `{yy}`, `{MM}`, `{M}`, `{MMMM}`, `{MMM}`, `{dd}`, `{d}`. Example: `Meetings/{yyyy}/{MM}` |
 | Filename pattern | `{date} {title}` | Pattern for filenames. Supports `{date}`, `{title}`, `{id}` |
 | Template path | `Templates/Granola.md` | Path to your template file |
 | Show ribbon icon | On | Show a sync button in the left sidebar |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-granola-simple-plugin",
-	"version": "1.0.1",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-granola-simple-plugin",
-			"version": "1.0.1",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.27.1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import {
 	parseTranscriptResponse,
 	buildMeetingData,
 } from "./response-parser";
-import { loadTemplate, applyTemplate, generateFilename } from "./template";
+import { loadTemplate, applyTemplate, generateFilename, resolveFolderPath, getFolderBasePath } from "./template";
 
 interface PluginData extends GranolaSyncSettings {
 	oauthTokens?: OAuthTokens;
@@ -199,6 +199,23 @@ export default class GranolaSyncPlugin extends Plugin {
 		}
 	}
 
+	private async ensureFolderPath(folderPath: string): Promise<void> {
+		if (!folderPath) return;
+		if (this.app.vault.getAbstractFileByPath(folderPath)) return;
+
+		const lastSlash = folderPath.lastIndexOf("/");
+		if (lastSlash > 0) {
+			await this.ensureFolderPath(folderPath.slice(0, lastSlash));
+		}
+
+		try {
+			await this.app.vault.createFolder(folderPath);
+		} catch {
+			// Ignore if it was created concurrently
+			if (!this.app.vault.getAbstractFileByPath(folderPath)) throw new Error(`Failed to create folder: ${folderPath}`);
+		}
+	}
+
 	private async doSync(manual: boolean): Promise<void> {
 		if (!this.isAuthenticated()) {
 			if (manual) {
@@ -207,7 +224,7 @@ export default class GranolaSyncPlugin extends Plugin {
 			return;
 		}
 
-		const folderPathSetting = this.settings.folderPath || DEFAULT_SETTINGS.folderPath;
+		const folderPathPattern = this.settings.folderPath || DEFAULT_SETTINGS.folderPath;
 		const templatePath = this.settings.templatePath || DEFAULT_SETTINGS.templatePath;
 		const filenamePattern = this.settings.filenamePattern || DEFAULT_SETTINGS.filenamePattern;
 
@@ -252,12 +269,11 @@ export default class GranolaSyncPlugin extends Plugin {
 			return;
 		}
 
-		// Ensure folder exists
-		const folderPath = normalizePath(folderPathSetting);
-		const folder = this.app.vault.getAbstractFileByPath(folderPath);
-		if (!folder) {
+		// Ensure base folder exists (the static prefix before any date tokens)
+		const baseFolderPath = normalizePath(getFolderBasePath(folderPathPattern));
+		if (baseFolderPath) {
 			try {
-				await this.app.vault.createFolder(folderPath);
+				await this.ensureFolderPath(baseFolderPath);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : "Unknown error";
 				new Notice(`Error creating folder: ${message}`);
@@ -266,11 +282,12 @@ export default class GranolaSyncPlugin extends Plugin {
 		}
 
 		// Build map of existing granola_id -> file
+		// Search within the base folder (or entire vault if pattern has no static prefix)
 		const existingDocs = new Map<string, TFile>();
 		const files = this.app.vault.getMarkdownFiles();
-		const folderPrefix = folderPath + "/";
+		const folderPrefix = baseFolderPath ? baseFolderPath + "/" : "";
 		for (const file of files) {
-			if (!file.path.startsWith(folderPrefix)) continue;
+			if (folderPrefix && !file.path.startsWith(folderPrefix)) continue;
 			const fileCache = this.app.metadataCache.getFileCache(file);
 			const granolaId = fileCache?.frontmatter?.granola_id as string | undefined;
 			if (granolaId) {
@@ -350,8 +367,10 @@ export default class GranolaSyncPlugin extends Plugin {
 					await this.app.vault.modify(existingFile, content);
 					updated++;
 				} else {
+					const meetingFolderPath = normalizePath(resolveFolderPath(folderPathPattern, meetingData));
+					await this.ensureFolderPath(meetingFolderPath);
 					const filename = generateFilename(filenamePattern, meetingData);
-					const filePath = normalizePath(`${folderPath}/${filename}.md`);
+					const filePath = normalizePath(`${meetingFolderPath}/${filename}.md`);
 					await this.app.vault.create(filePath, content);
 					created++;
 				}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -161,7 +161,11 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Folder path")
-			.setDesc("Where to save meeting notes in your vault")
+			.setDesc(
+				"Where to save meeting notes in your vault. " +
+				"Use date tokens to organize by date: {yyyy}, {yy}, {MM}, {M}, {MMMM}, {MMM}, {dd}, {d}. " +
+				"Example: Meetings/{yyyy}/{MM}"
+			)
 			.addText((text) =>
 				text
 					.setPlaceholder("Meetings")

--- a/src/template.ts
+++ b/src/template.ts
@@ -94,3 +94,45 @@ export function generateFilename(pattern: string, meeting: MeetingData): string 
 		.replace("{title}", title)
 		.replace("{id}", id);
 }
+
+/**
+ * Resolve date tokens in a folder path pattern using the meeting's date.
+ * Supported tokens: {yyyy}, {yy}, {MMMM}, {MMM}, {MM}, {M}, {dd}, {d}
+ */
+export function resolveFolderPath(pattern: string, meeting: MeetingData): string {
+	if (!pattern.includes("{")) return pattern;
+
+	const dateStr = meeting.date || new Date().toISOString().slice(0, 10);
+	const [year, month, day] = dateStr.split("-").map(Number);
+	// Use local date constructor to avoid UTC/timezone shifts
+	const date = new Date(year, month - 1, day);
+
+	const tokens: Record<string, string> = {
+		yyyy: String(date.getFullYear()),
+		yy: String(date.getFullYear()).slice(-2),
+		MMMM: date.toLocaleString("en-US", { month: "long" }),
+		MMM: date.toLocaleString("en-US", { month: "short" }),
+		MM: String(date.getMonth() + 1).padStart(2, "0"),
+		M: String(date.getMonth() + 1),
+		dd: String(date.getDate()).padStart(2, "0"),
+		d: String(date.getDate()),
+	};
+
+	// Order matters: longer tokens must be listed before shorter prefixes (e.g. MMMM before MMM before MM before M)
+	return pattern.replace(
+		/\{(yyyy|yy|MMMM|MMM|MM|M|dd|d)\}/g,
+		(_, token: string) => tokens[token] ?? `{${token}}`,
+	);
+}
+
+/**
+ * Return the static base portion of a folder path pattern (everything before the first token).
+ * e.g. "Meetings/{yyyy}/{MM}" → "Meetings"
+ *      "Meetings" → "Meetings"
+ *      "{yyyy}/{MM}" → ""
+ */
+export function getFolderBasePath(pattern: string): string {
+	const tokenIndex = pattern.indexOf("{");
+	if (tokenIndex === -1) return pattern;
+	return pattern.slice(0, tokenIndex).replace(/\/+$/, "");
+}


### PR DESCRIPTION
Users can now use date tokens in the folder path setting to auto-organize meeting notes into date-based subdirectories. For example, `Meetings/{yyyy}/{MM}` will save notes under `Meetings/2024/03/` based on the meeting date.

Supported tokens: {yyyy}, {yy}, {MMMM}, {MMM}, {MM}, {M}, {dd}, {d}

- Add resolveFolderPath() to resolve tokens against a meeting's date
- Add getFolderBasePath() to extract the static prefix for vault scanning
- Add ensureFolderPath() for recursive folder creation
- Update doSync() to resolve per-meeting folder paths dynamically
- Update settings description and README to document the feature