### PR TITLE
Add per-meeting routing rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-granola-simple-plugin",
-	"version": "1.0.1",
+	"version": "2.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-granola-simple-plugin",
-			"version": "1.0.1",
+			"version": "2.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.27.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"lint": "eslint .",
 		"typecheck": "tsc --noEmit",
 		"build": "node esbuild.config.mjs production",
-		"package": "npm run build && mkdir -p release/granola-meetings-simple-sync && cp main.js manifest.json versions.json release/granola-meetings-simple-sync/ && cd release && zip -r granola-meetings-simple-sync.zip granola-meetings-simple-sync",
+		"package": "npm run build && mkdir -p release/granola-meetings-simple-sync && cp main.js manifest.json versions.json styles.css release/granola-meetings-simple-sync/ && cd release && zip -r granola-meetings-simple-sync.zip granola-meetings-simple-sync",
 		"deploy-local": "source .env && npm run package && cp \"$OBSIDIAN_PLUGINS/granola-meetings-simple-sync/data.json\" release/granola-meetings-simple-sync/data.json 2>/dev/null; rm -rf \"$OBSIDIAN_PLUGINS/granola-meetings-simple-sync\" && mv release/granola-meetings-simple-sync \"$OBSIDIAN_PLUGINS/\"",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,24 +178,6 @@ export default class GranolaSyncPlugin extends Plugin {
 		if (data?.autoSyncOnStartup !== undefined && !data.syncFrequency) {
 			this.settings.syncFrequency = data.autoSyncOnStartup ? "startup" : "manual";
 		}
-
-		// Migrate routing rules: legacy `flags` field is folded into `pattern`
-		// using /pattern/flags slash syntax. Rules with the default flag "i"
-		// just have the field stripped (default is unchanged).
-		let migratedRouting = false;
-		for (const rule of this.settings.routingRules) {
-			const legacy = rule as typeof rule & { flags?: string };
-			if (legacy.flags && legacy.flags !== "i") {
-				const escaped = rule.pattern.replace(/\//g, "\\/");
-				rule.pattern = `/${escaped}/${legacy.flags}`;
-				migratedRouting = true;
-			}
-			if ("flags" in legacy) {
-				delete legacy.flags;
-				migratedRouting = true;
-			}
-		}
-		if (migratedRouting) await this.saveSettings();
 	}
 
 	async saveSettings(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {
 	buildMeetingData,
 } from "./response-parser";
 import { loadTemplate, applyTemplate, generateFilename } from "./template";
+import { resolveFolder } from "./routing";
 
 interface PluginData extends GranolaSyncSettings {
 	oauthTokens?: OAuthTokens;
@@ -177,6 +178,24 @@ export default class GranolaSyncPlugin extends Plugin {
 		if (data?.autoSyncOnStartup !== undefined && !data.syncFrequency) {
 			this.settings.syncFrequency = data.autoSyncOnStartup ? "startup" : "manual";
 		}
+
+		// Migrate routing rules: legacy `flags` field is folded into `pattern`
+		// using /pattern/flags slash syntax. Rules with the default flag "i"
+		// just have the field stripped (default is unchanged).
+		let migratedRouting = false;
+		for (const rule of this.settings.routingRules) {
+			const legacy = rule as typeof rule & { flags?: string };
+			if (legacy.flags && legacy.flags !== "i") {
+				const escaped = rule.pattern.replace(/\//g, "\\/");
+				rule.pattern = `/${escaped}/${legacy.flags}`;
+				migratedRouting = true;
+			}
+			if ("flags" in legacy) {
+				delete legacy.flags;
+				migratedRouting = true;
+			}
+		}
+		if (migratedRouting) await this.saveSettings();
 	}
 
 	async saveSettings(): Promise<void> {
@@ -186,6 +205,18 @@ export default class GranolaSyncPlugin extends Plugin {
 
 	private async savePluginData(): Promise<void> {
 		await this.saveData(this.pluginData);
+	}
+
+	private async ensureFolder(path: string): Promise<void> {
+		const normalized = normalizePath(path);
+		if (!normalized || normalized === "/" || normalized === ".") return;
+		if (this.app.vault.getAbstractFileByPath(normalized)) return;
+		try {
+			await this.app.vault.createFolder(normalized);
+		} catch (error) {
+			// Folder may have been created concurrently; only re-throw if it still doesn't exist.
+			if (!this.app.vault.getAbstractFileByPath(normalized)) throw error;
+		}
 	}
 
 	async syncMeetings(manual = false): Promise<void> {
@@ -252,25 +283,13 @@ export default class GranolaSyncPlugin extends Plugin {
 			return;
 		}
 
-		// Ensure folder exists
 		const folderPath = normalizePath(folderPathSetting);
-		const folder = this.app.vault.getAbstractFileByPath(folderPath);
-		if (!folder) {
-			try {
-				await this.app.vault.createFolder(folderPath);
-			} catch (error) {
-				const message = error instanceof Error ? error.message : "Unknown error";
-				new Notice(`Error creating folder: ${message}`);
-				return;
-			}
-		}
 
-		// Build map of existing granola_id -> file
+		// Build map of existing granola_id -> file (scan whole vault so we find
+		// notes even if a routing rule has changed their destination folder).
 		const existingDocs = new Map<string, TFile>();
 		const files = this.app.vault.getMarkdownFiles();
-		const folderPrefix = folderPath + "/";
 		for (const file of files) {
-			if (!file.path.startsWith(folderPrefix)) continue;
 			const fileCache = this.app.metadataCache.getFileCache(file);
 			const granolaId = fileCache?.frontmatter?.granola_id as string | undefined;
 			if (granolaId) {
@@ -355,8 +374,12 @@ export default class GranolaSyncPlugin extends Plugin {
 					await this.app.vault.modify(existingFile, content);
 					updated++;
 				} else {
+					const destFolder = normalizePath(
+						resolveFolder(meetingData, this.settings.routingRules, folderPath),
+					);
+					await this.ensureFolder(destFolder);
 					const filename = generateFilename(filenamePattern, meetingData);
-					const filePath = normalizePath(`${folderPath}/${filename}.md`);
+					const filePath = normalizePath(`${destFolder}/${filename}.md`);
 					await this.app.vault.create(filePath, content);
 					created++;
 				}

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,0 +1,88 @@
+import type { MeetingData } from "./response-parser";
+import type { RoutingRule } from "./settings";
+
+const SLASH_SYNTAX = /^\/(.+)\/([gimsuy]*)$/;
+const DEFAULT_FLAGS = "i";
+
+export function buildHaystack(meeting: MeetingData): string {
+	const orgs = meeting.participants.map((p) => p.organization).filter(Boolean);
+	const emails = meeting.participants.map((p) => p.email).filter(Boolean);
+	const names = meeting.participants.map((p) => p.name).filter(Boolean);
+	return [
+		`TITLE: ${meeting.title}`,
+		`ORG: ${orgs.join(", ")}`,
+		`EMAIL: ${emails.join(", ")}`,
+		`NAME: ${names.join(", ")}`,
+	].join("\n");
+}
+
+interface ParsedLine {
+	source: string;
+	flags: string;
+}
+
+function parseLine(line: string): ParsedLine {
+	const m = line.match(SLASH_SYNTAX);
+	if (m) return { source: m[1], flags: m[2] || DEFAULT_FLAGS };
+	return { source: line, flags: DEFAULT_FLAGS };
+}
+
+function splitNonBlankLines(pattern: string): { line: string; index: number }[] {
+	const out: { line: string; index: number }[] = [];
+	pattern.split("\n").forEach((raw, i) => {
+		const trimmed = raw.trim();
+		if (trimmed) out.push({ line: trimmed, index: i + 1 });
+	});
+	return out;
+}
+
+export function compileRule(rule: RoutingRule): RegExp[] {
+	const compiled: RegExp[] = [];
+	for (const { line } of splitNonBlankLines(rule.pattern)) {
+		const { source, flags } = parseLine(line);
+		try {
+			compiled.push(new RegExp(source, flags));
+		} catch {
+			// Skip invalid line; the editor surfaces the error.
+		}
+	}
+	return compiled;
+}
+
+export interface PatternError {
+	line: number;
+	message: string;
+}
+
+export function validateRulePattern(pattern: string): { errors: PatternError[] } {
+	const errors: PatternError[] = [];
+	for (const { line, index } of splitNonBlankLines(pattern)) {
+		const { source, flags } = parseLine(line);
+		try {
+			new RegExp(source, flags);
+		} catch (e) {
+			errors.push({
+				line: index,
+				message: e instanceof Error ? e.message : "Invalid regex",
+			});
+		}
+	}
+	return { errors };
+}
+
+export function resolveFolder(
+	meeting: MeetingData,
+	rules: RoutingRule[],
+	defaultFolder: string,
+): string {
+	const haystack = buildHaystack(meeting);
+	for (const rule of rules) {
+		if (!rule.enabled) continue;
+		if (!rule.destinationFolder.trim()) continue;
+		const compiled = compileRule(rule);
+		if (compiled.some((regex) => regex.test(haystack))) {
+			return rule.destinationFolder.trim().replace(/^\/+/, "");
+		}
+	}
+	return defaultFolder;
+}

--- a/src/rule-edit-modal.ts
+++ b/src/rule-edit-modal.ts
@@ -1,0 +1,123 @@
+import { App, Modal, Setting } from "obsidian";
+import type { RoutingRule } from "./settings";
+import { validateRulePattern } from "./routing";
+
+export type RuleEditMode = "create" | "edit";
+
+interface StackedRowOptions {
+	name: string;
+	description?: string;
+}
+
+function createStackedRow(parent: HTMLElement, opts: StackedRowOptions): HTMLElement {
+	const row = parent.createDiv({ cls: "granola-rule-row" });
+	row.createDiv({ cls: "setting-item-name", text: opts.name });
+	if (opts.description) {
+		row.createDiv({ cls: "setting-item-description", text: opts.description });
+	}
+	return row;
+}
+
+export class RoutingRuleEditModal extends Modal {
+	private readonly draft: RoutingRule;
+
+	constructor(
+		app: App,
+		initial: RoutingRule,
+		private readonly mode: RuleEditMode,
+		private readonly onSave: (rule: RoutingRule) => void | Promise<void>,
+	) {
+		super(app);
+		this.draft = { ...initial };
+	}
+
+	override onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.createEl("h2", {
+			text: this.mode === "create" ? "Add routing rule" : "Edit routing rule",
+		});
+
+		// Label
+		const labelRow = createStackedRow(contentEl, {
+			name: "Label",
+			description: "Optional name shown in the rules list",
+		});
+		const labelInput = labelRow.createEl("input", { type: "text" });
+		// eslint-disable-next-line obsidianmd/ui/sentence-case
+		labelInput.placeholder = "e.g. client work";
+		labelInput.value = this.draft.label ?? "";
+		labelInput.addEventListener("input", () => {
+			this.draft.label = labelInput.value;
+		});
+
+		// Patterns
+		const patternsRow = createStackedRow(contentEl, {
+			name: "Patterns",
+			description:
+				"One regex per line. The rule matches if any line matches. Wrap with /pattern/flags to override flags. Default flags: i (case-insensitive).",
+		});
+		const patternsInput = patternsRow.createEl("textarea");
+		patternsInput.rows = 6;
+		patternsInput.placeholder = "@example\\.com\nfirstname";
+		patternsInput.value = this.draft.pattern;
+		patternsInput.addEventListener("input", () => {
+			this.draft.pattern = patternsInput.value;
+			renderErrors();
+		});
+
+		const errorEl = patternsRow.createDiv({ cls: "granola-rule-errors" });
+		const renderErrors = () => {
+			const { errors } = validateRulePattern(this.draft.pattern);
+			if (errors.length === 0) {
+				errorEl.setText("");
+				errorEl.toggleClass("mod-warning", false);
+			} else {
+				errorEl.setText(
+					errors.map((e) => `Line ${e.line}: ${e.message}`).join("\n"),
+				);
+				errorEl.toggleClass("mod-warning", true);
+			}
+		};
+		renderErrors();
+
+		const hint = patternsRow.createDiv({ cls: "granola-rule-hint" });
+		hint.setText(
+			// eslint-disable-next-line obsidianmd/ui/sentence-case
+			"Tested against a multi-line haystack with TITLE / ORG / EMAIL / NAME prefixes. Use anchors like ^TITLE: with the m flag to scope to one line.",
+		);
+
+		// Destination folder
+		const destRow = createStackedRow(contentEl, {
+			name: "Destination folder",
+			description: "Vault-relative path. The folder is created if it doesn't exist.",
+		});
+		const destInput = destRow.createEl("input", { type: "text" });
+		destInput.placeholder = "e.g. Clients/Acme";
+		destInput.value = this.draft.destinationFolder;
+		destInput.addEventListener("input", () => {
+			this.draft.destinationFolder = destInput.value;
+		});
+
+		// Action buttons
+		new Setting(contentEl)
+			.addButton((btn) =>
+				btn.setButtonText("Cancel").onClick(() => {
+					this.close();
+				}),
+			)
+			.addButton((btn) =>
+				btn
+					.setButtonText("Save")
+					.setCta()
+					.onClick(async () => {
+						await this.onSave(this.draft);
+						this.close();
+					}),
+			);
+	}
+
+	override onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import type GranolaSyncPlugin from "./main";
 import type { SyncTimeRange } from "./mcp-client";
+import { RoutingRuleEditModal } from "./rule-edit-modal";
 
 export type SyncFrequency = "manual" | "startup" | "1m" | "15m" | "30m" | "60m" | "12h";
 
@@ -30,6 +31,24 @@ const SYNC_TIME_RANGE_OPTIONS: Record<SyncTimeRange, string> = {
 	last_30_days: "Last 30 days",
 };
 
+export interface RoutingRule {
+	id: string;
+	enabled: boolean;
+	pattern: string; // multi-line; each non-blank line is one regex (logical OR)
+	destinationFolder: string;
+	label?: string;
+}
+
+export function blankRoutingRule(): RoutingRule {
+	return {
+		id: newRoutingRuleId(),
+		enabled: true,
+		pattern: "",
+		destinationFolder: "",
+		label: "",
+	};
+}
+
 export interface GranolaSyncSettings {
 	folderPath: string;
 	filenamePattern: string;
@@ -40,6 +59,7 @@ export interface GranolaSyncSettings {
 	matchAttendeesByEmail: boolean;
 	syncTimeRange: SyncTimeRange;
 	syncTranscripts: boolean;
+	routingRules: RoutingRule[];
 }
 
 export const DEFAULT_SETTINGS: GranolaSyncSettings = {
@@ -52,7 +72,15 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
 	matchAttendeesByEmail: true,
 	syncTimeRange: "last_30_days",
 	syncTranscripts: false,
+	routingRules: [],
 };
+
+function newRoutingRuleId(): string {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID();
+	}
+	return `rule-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
 
 export class GranolaSyncSettingTab extends PluginSettingTab {
 	plugin: GranolaSyncPlugin;
@@ -238,5 +266,133 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		// --- Routing rules section ---
+		new Setting(containerEl)
+			.setName("Routing rules")
+			.setHeading()
+			.addExtraButton((btn) =>
+				btn
+					.setIcon("plus")
+					.setTooltip("Add rule")
+					.onClick(() => {
+						const draft = blankRoutingRule();
+						new RoutingRuleEditModal(
+							this.plugin.app,
+							draft,
+							"create",
+							async (saved) => {
+								this.plugin.settings.routingRules.push(saved);
+								await this.plugin.saveSettings();
+								this.display();
+							},
+						).open();
+					}),
+			);
+
+		const rulesContainer = containerEl.createDiv({ cls: "granola-routing-rules" });
+		this.renderRoutingRules(rulesContainer);
 	}
+
+	private renderRoutingRules(container: HTMLElement): void {
+		container.empty();
+		const rules = this.plugin.settings.routingRules;
+
+		if (rules.length === 0) {
+			const empty = container.createEl("p", { cls: "setting-item-description" });
+			empty.setText("No rules configured. Use the button below to add one.");
+			return;
+		}
+
+		rules.forEach((rule, index) => {
+			const summary = summarizeRule(rule);
+			const setting = new Setting(container)
+				.setName(rule.label?.trim() || `Rule ${index + 1}`)
+				.setDesc(summary)
+				.addToggle((toggle) =>
+					toggle
+						.setTooltip("Enable or disable this rule")
+						.setValue(rule.enabled)
+						.onChange(async (value) => {
+							rule.enabled = value;
+							await this.plugin.saveSettings();
+						}),
+				)
+				.addExtraButton((btn) =>
+					btn
+						.setIcon("pencil")
+						.setTooltip("Edit rule")
+						.onClick(() => {
+							new RoutingRuleEditModal(
+								this.plugin.app,
+								rule,
+								"edit",
+								async (saved) => {
+									Object.assign(rule, saved);
+									await this.plugin.saveSettings();
+									this.display();
+								},
+							).open();
+						}),
+				)
+				.addExtraButton((btn) =>
+					btn
+						.setIcon("arrow-up")
+						.setTooltip("Move up")
+						.setDisabled(index === 0)
+						.onClick(async () => {
+							if (index === 0) return;
+							const tmp = rules[index - 1];
+							rules[index - 1] = rule;
+							rules[index] = tmp;
+							await this.plugin.saveSettings();
+							this.display();
+						}),
+				)
+				.addExtraButton((btn) =>
+					btn
+						.setIcon("arrow-down")
+						.setTooltip("Move down")
+						.setDisabled(index === rules.length - 1)
+						.onClick(async () => {
+							if (index === rules.length - 1) return;
+							const tmp = rules[index + 1];
+							rules[index + 1] = rule;
+							rules[index] = tmp;
+							await this.plugin.saveSettings();
+							this.display();
+						}),
+				)
+				.addExtraButton((btn) =>
+					btn
+						.setIcon("trash")
+						.setTooltip("Delete rule")
+						.onClick(async () => {
+							rules.splice(index, 1);
+							await this.plugin.saveSettings();
+							this.display();
+						}),
+				);
+
+			if (!rule.enabled) {
+				setting.settingEl.addClass("granola-routing-rule-disabled");
+			}
+		});
+	}
+}
+
+function summarizeRule(rule: RoutingRule): string {
+	const lines = rule.pattern
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+	if (lines.length === 0) {
+		return rule.destinationFolder
+			? `(no pattern) → ${rule.destinationFolder}`
+			: "(no pattern, no destination)";
+	}
+	const first = lines[0].length > 50 ? `${lines[0].slice(0, 47)}...` : lines[0];
+	const more = lines.length > 1 ? ` +${lines.length - 1} more` : "";
+	const dest = rule.destinationFolder.trim() || "(no destination)";
+	return `${first}${more} → ${dest}`;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,57 @@
+/* Routing rule edit modal — stacked rows */
+.granola-rule-row {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 12px 0;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.granola-rule-row:first-of-type {
+	border-top: none;
+}
+
+.granola-rule-row .setting-item-name {
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-medium);
+}
+
+.granola-rule-row .setting-item-description {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	margin-bottom: 4px;
+}
+
+.granola-rule-row input[type="text"],
+.granola-rule-row textarea {
+	width: 100%;
+	box-sizing: border-box;
+	font-family: var(--font-monospace);
+}
+
+.granola-rule-row textarea {
+	resize: vertical;
+	min-height: 90px;
+}
+
+.granola-rule-hint {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	margin-top: 6px;
+	line-height: 1.4;
+}
+
+.granola-rule-hint code {
+	font-size: 0.95em;
+}
+
+.granola-rule-errors {
+	font-size: var(--font-ui-smaller);
+	margin-top: 6px;
+	white-space: pre-line;
+}
+
+.granola-routing-rule-disabled .setting-item-name,
+.granola-routing-rule-disabled .setting-item-description {
+	opacity: 0.55;
+}


### PR DESCRIPTION
This adds the ability to route a meeting based on its metadata to a specific folder. For example, you can look for specific domains in email addresses or the meeting title using regex, and save that meeting to a specific folder in your vault. If no rule matches, it goes to your default folder.

- New RoutingRule type with multi-line patterns (one regex per line, OR-joined) and optional /pattern/flags slash syntax for per-line flag overrides. Default flags: i (case-insensitive).
- src/routing.ts builds a labeled haystack (TITLE/ORG/EMAIL/NAME) and returns the first matching enabled rule's destination folder.
- doSync now scans the entire vault for granola_id so re-routing doesn't create duplicates, and creates destination folders lazily via a new ensureFolder helper. Existing notes stay in place when rules change.

<img width="2804" height="2740" alt="CleanShot 2026-04-27 at 11 00 58@2x" src="https://github.com/user-attachments/assets/5911a829-1b67-4615-83d5-8461887e93ec" />

<img width="2804" height="2740" alt="CleanShot 2026-04-27 at 11 00 51@2x" src="https://github.com/user-attachments/assets/18546dc3-0faf-4e08-8a65-ce4b7727e674" />
