### PR TITLE
Add date-formatted folder paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ To sync more than one Granola account, click **Add Granola account** in settings
 | Time range | Last 30 days | How far back to look for meetings |
 | Sync frequency | Every 15 minutes | How often to sync. Options: Manual only, On startup, 1m, 15m, 30m, 60m, 12h |
 | Sync transcripts | Off | Include full meeting transcripts (1 extra API call per meeting) |
-| Folder path | `Meetings` | Where to save meeting notes |
-| Filename pattern | `{date} {title}` | Pattern for filenames. Supports `{date}`, `{title}`, `{id}` |
+| Folder path | `Meetings` | Where to save meeting notes. Supports date formatting, e.g. `Meetings/{date:YYYY/MM}` |
+| Filename pattern | `{date} {title}` | Pattern for filenames. Supports `{date}`, `{date:YYYY-MM-DD}`, `{title}`, `{id}` |
 | Template path | `Templates/Granola.md` | Path to your template file |
 | Show ribbon icon | On | Show a sync button in the left sidebar |
 | Skip existing notes | On | Don't overwrite notes you've edited |

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {
 	parseAccountInfo,
 	buildMeetingData,
 } from "./response-parser";
-import { loadTemplate, applyTemplate, generateFilename } from "./template";
+import { loadTemplate, applyTemplate, generateFilename, getFolderBasePath, resolveDatePattern } from "./template";
 
 export interface GranolaAccount {
 	id: string;
@@ -352,24 +352,22 @@ export default class GranolaSyncPlugin extends Plugin {
 		}
 
 		// Ensure folder exists
-		const folderPath = normalizePath(folderPathSetting);
-		const folder = this.app.vault.getAbstractFileByPath(folderPath);
-		if (!folder) {
-			try {
-				await this.app.vault.createFolder(folderPath);
-			} catch (error) {
-				const message = error instanceof Error ? error.message : "Unknown error";
-				new Notice(`Error creating folder: ${message}`);
-				return;
-			}
+		const folderPathPattern = normalizePath(folderPathSetting);
+		const folderBasePath = normalizePath(getFolderBasePath(folderPathPattern) || DEFAULT_SETTINGS.folderPath);
+		try {
+			await this.ensureFolderExists(folderBasePath);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			new Notice(`Error creating folder: ${message}`);
+			return;
 		}
 
 		// Build map of existing granola_id -> file (shared across all accounts)
 		const existingDocs = new Map<string, TFile>();
 		const files = this.app.vault.getMarkdownFiles();
-		const folderPrefix = folderPath + "/";
+		const folderPrefix = folderBasePath ? folderBasePath + "/" : "";
 		for (const file of files) {
-			if (!file.path.startsWith(folderPrefix)) continue;
+			if (folderPrefix && file.path !== folderBasePath && !file.path.startsWith(folderPrefix)) continue;
 			const fileCache = this.app.metadataCache.getFileCache(file);
 			const granolaId = fileCache?.frontmatter?.granola_id as string | undefined;
 			if (granolaId) {
@@ -397,7 +395,7 @@ export default class GranolaSyncPlugin extends Plugin {
 
 		const ctx: SyncContext = {
 			template,
-			folderPath,
+			folderPathPattern,
 			filenamePattern,
 			existingDocs,
 			emailToNoteTitle,
@@ -432,6 +430,19 @@ export default class GranolaSyncPlugin extends Plugin {
 				message += `. ${failedAccounts} account${failedAccounts !== 1 ? "s" : ""} failed — check console.`;
 			}
 			new Notice(message);
+		}
+	}
+
+	private async ensureFolderExists(folderPath: string): Promise<void> {
+		const normalizedPath = normalizePath(folderPath);
+		const parts = normalizedPath.split("/").filter(Boolean);
+		let currentPath = "";
+
+		for (const part of parts) {
+			currentPath = currentPath ? `${currentPath}/${part}` : part;
+			if (!this.app.vault.getAbstractFileByPath(currentPath)) {
+				await this.app.vault.createFolder(currentPath);
+			}
 		}
 	}
 
@@ -535,8 +546,14 @@ export default class GranolaSyncPlugin extends Plugin {
 					await this.app.vault.modify(existingFile, content);
 					updated++;
 				} else {
+					const folderPath = normalizePath(resolveDatePattern(ctx.folderPathPattern, meetingData.date));
+					await this.ensureFolderExists(folderPath);
 					const filename = generateFilename(ctx.filenamePattern, meetingData);
-					const filePath = normalizePath(`${ctx.folderPath}/${filename}.md`);
+					const filePath = normalizePath(`${folderPath}/${filename}.md`);
+					const lastSlash = filePath.lastIndexOf("/");
+					if (lastSlash > 0) {
+						await this.ensureFolderExists(filePath.substring(0, lastSlash));
+					}
 					const newFile = await this.app.vault.create(filePath, content);
 					// Track so a meeting shared across accounts isn't created twice this run.
 					ctx.existingDocs.set(details.id, newFile);
@@ -553,7 +570,7 @@ export default class GranolaSyncPlugin extends Plugin {
 
 interface SyncContext {
 	template: string;
-	folderPath: string;
+	folderPathPattern: string;
 	filenamePattern: string;
 	existingDocs: Map<string, TFile>;
 	emailToNoteTitle: Map<string, string>;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -193,7 +193,7 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Folder path")
-			.setDesc("Where to save meeting notes in your vault")
+			.setDesc("Where to save meeting notes. Supports date formatting, e.g. Meetings/{date:YYYY/MM}")
 			.addText((text) =>
 				text
 					.setPlaceholder("Meetings")
@@ -206,7 +206,7 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Filename pattern")
-			.setDesc("Pattern for note filenames. Available: {date}, {title}, {id}")
+			.setDesc("Pattern for note filenames. Available: {date}, {date:YYYY-MM-DD}, {title}, {id}")
 			.addText((text) =>
 				text
 					.setPlaceholder("{date} {title}")

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { applyTemplate, sanitizeFilename, generateFilename } from "./template";
+import { applyTemplate, sanitizeFilename, generateFilename, getFolderBasePath, resolveDatePattern } from "./template";
 import type { MeetingData } from "./response-parser";
 
 function meeting(overrides: Partial<MeetingData> = {}): MeetingData {
@@ -74,10 +74,54 @@ describe("sanitizeFilename", () => {
 	});
 });
 
+describe("resolveDatePattern", () => {
+	it("expands date format tokens in folder paths", () => {
+		expect(resolveDatePattern("Granola/{date:YYYY/MM/DD}", "2026-03-03")).toBe("Granola/2026/03/03");
+		expect(resolveDatePattern("Granola/{date:YY/M/D}", "2026-03-03")).toBe("Granola/26/3/3");
+		expect(resolveDatePattern("Granola/{date:MMMM}/{date:MMM}", "2026-03-03")).toBe("Granola/March/Mar");
+	});
+
+	it("expands {date} without a format as ISO date", () => {
+		expect(resolveDatePattern("Granola/{date}", "2026-03-03")).toBe("Granola/2026-03-03");
+	});
+
+	it("leaves unknown folder path placeholders untouched", () => {
+		expect(resolveDatePattern("Granola/{date:YYYY}/{unknown}", "2026-03-03")).toBe("Granola/2026/{unknown}");
+	});
+});
+
+describe("getFolderBasePath", () => {
+	it("returns the static prefix before the first date token", () => {
+		expect(getFolderBasePath("Granola/{date:YYYY/MM/DD}")).toBe("Granola");
+		expect(getFolderBasePath("Granola/Meetings/{date}")).toBe("Granola/Meetings");
+	});
+
+	it("returns the whole path when no date tokens are present", () => {
+		expect(getFolderBasePath("Meetings")).toBe("Meetings");
+	});
+});
+
 describe("generateFilename", () => {
 	it("expands the date, title, and id placeholders", () => {
 		expect(generateFilename("{date} {title}", meeting())).toBe("2026-03-03 Weekly Sync");
 		expect(generateFilename("{id}-{title}", meeting())).toBe("abc12345-Weekly Sync");
+	});
+
+	it("expands formatted date placeholders", () => {
+		expect(generateFilename("{date:YYYY/MM/DD} {title}", meeting())).toBe("2026/03/03 Weekly Sync");
+		expect(generateFilename("{date:YYYY-MM}", meeting())).toBe("2026-03");
+		expect(generateFilename("{date:YY-M-D}", meeting())).toBe("26-3-3");
+		expect(generateFilename("{date:MMMM}-{date:MMM}", meeting())).toBe("March-Mar");
+	});
+
+	it("expands repeated placeholders", () => {
+		expect(generateFilename("{date} {date} {title} {title} {id} {id}", meeting())).toBe(
+			"2026-03-03 2026-03-03 Weekly Sync Weekly Sync abc12345 abc12345",
+		);
+	});
+
+	it("leaves unknown filename placeholders untouched", () => {
+		expect(generateFilename("{date} {unknown} {title}", meeting())).toBe("2026-03-03 {unknown} Weekly Sync");
 	});
 
 	it("sanitizes the title within the filename", () => {

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,4 +1,4 @@
-import { App, normalizePath, TFile } from "obsidian";
+import { App, moment, normalizePath, TFile } from "obsidian";
 import type { MeetingData, ParsedParticipant } from "./response-parser";
 import DEFAULT_TEMPLATE from "./default-template.md";
 
@@ -85,12 +85,28 @@ export function sanitizeFilename(name: string): string {
 		.slice(0, 100);
 }
 
+function formatMeetingDate(date: string, format = "YYYY-MM-DD"): string {
+	const parseDate = moment as unknown as (input: string, format: string) => { format: (format: string) => string };
+	return parseDate(date, "YYYY-MM-DD").format(format);
+}
+
+export function resolveDatePattern(pattern: string, date: string): string {
+	return pattern.replace(/\{date(?::([^}]+))?\}/g, (_, format: string | undefined) =>
+		formatMeetingDate(date, format),
+	);
+}
+
+export function getFolderBasePath(folderPattern: string): string {
+	const firstToken = folderPattern.search(/\{date(?::[^}]+)?\}/);
+	if (firstToken === -1) return folderPattern;
+	return folderPattern.slice(0, firstToken).replace(/\/+$/, "");
+}
+
 export function generateFilename(pattern: string, meeting: MeetingData): string {
 	const title = sanitizeFilename(meeting.title);
 	const id = meeting.id.slice(0, 8);
 
-	return pattern
-		.replace("{date}", meeting.date)
-		.replace("{title}", title)
-		.replace("{id}", id);
+	return resolveDatePattern(pattern, meeting.date)
+		.replace(/\{title\}/g, title)
+		.replace(/\{id\}/g, id);
 }

--- a/test/stubs/obsidian.ts
+++ b/test/stubs/obsidian.ts
@@ -2,9 +2,13 @@
 // (e.g. template.ts) can be loaded under Vitest without the real Obsidian
 // runtime. Only the members our source touches are provided.
 
+import momentModule from "moment";
+
 export class TFile {}
 
 export class App {}
+
+export const moment = momentModule;
 
 export function normalizePath(path: string): string {
 	return path.replace(/\\/g, "/").replace(/\/+/g, "/");


### PR DESCRIPTION
## 𝚂𝚞𝚖𝚖𝚊𝚛𝚢

𝙰𝚍𝚍𝚜 𝚍𝚊𝚝𝚎 𝚏𝚘𝚛𝚖𝚊𝚝𝚝𝚒𝚗𝚐 𝚜𝚞𝚙𝚙𝚘𝚛𝚝 𝚝𝚘 𝚝𝚑𝚎 𝚏𝚘𝚕𝚍𝚎𝚛 𝚙𝚊𝚝𝚑 𝚜𝚎𝚝𝚝𝚒𝚗𝚐 𝚜𝚘 𝚖𝚎𝚎𝚝𝚒𝚗𝚐𝚜 𝚌𝚊𝚗 𝚋𝚎 𝚘𝚛𝚐𝚊𝚗𝚒𝚣𝚎𝚍 𝚒𝚗𝚝𝚘 𝚍𝚊𝚝𝚎-𝚋𝚊𝚜𝚎𝚍 𝚜𝚞𝚋𝚏𝚘𝚕𝚍𝚎𝚛𝚜.

𝙴𝚡𝚊𝚖𝚙𝚕𝚎:

```𝚝𝚎𝚡𝚝
𝙵𝚘𝚕𝚍𝚎𝚛 𝚙𝚊𝚝𝚑: 𝙼𝚎𝚎𝚝𝚒𝚗𝚐𝚜/{𝚍𝚊𝚝𝚎:𝚈𝚈𝚈𝚈/𝙼𝙼}
𝙵𝚒𝚕𝚎𝚗𝚊𝚖𝚎 𝚙𝚊𝚝𝚝𝚎𝚛𝚗: {𝚝𝚒𝚝𝚕𝚎}
```
creates:

```text
𝙼𝚎𝚎𝚝𝚒𝚗𝚐𝚜/𝟸𝟶𝟸𝟼/𝟶𝟼/𝙼𝚎𝚎𝚝𝚒𝚗𝚐 𝚃𝚒𝚝𝚕𝚎.𝚖𝚍
```

Also supports date formatting in filename patterns:
```text
{𝚍𝚊𝚝𝚎:𝚈𝚈𝚈𝚈-𝙼𝙼-𝙳𝙳} {𝚝𝚒𝚝𝚕𝚎}
```

Notes

• Uses Obsidian's exported 𝚖𝚘𝚖𝚎𝚗𝚝 instead of custom date-token parsing.
• Leaves 𝚙𝚊𝚌𝚔𝚊𝚐𝚎-𝚕𝚘𝚌𝚔.𝚓𝚜𝚘𝚗 unchanged.
• Adds tests for folder path date formatting, filename date formatting, repeated placeholders, and folder base-path extraction.
• Keeps {𝚍𝚊𝚝𝚎} as the existing ISO date behavior.

Verification

• 𝚗𝚙𝚖 𝚝𝚎𝚜𝚝
• 𝚗𝚙𝚖 𝚛𝚞𝚗 𝚝𝚢𝚙𝚎𝚌𝚑𝚎𝚌𝚔
• 𝚗𝚙𝚖 𝚛𝚞𝚗 𝚕𝚒𝚗𝚝
• 𝚗𝚙𝚖 𝚛𝚞𝚗 𝚋𝚞𝚒𝚕𝚍

Manual smoke test in temp Obsidian vault:
```text
𝙵𝚘𝚕𝚍𝚎𝚛 𝚙𝚊𝚝𝚑: 𝙶𝚛𝚊𝚗𝚘𝚕𝚊/{𝚍𝚊𝚝𝚎:𝚈𝚈𝚈𝚈/𝙼𝙼/𝙳𝙳}
𝙵𝚒𝚕𝚎𝚗𝚊𝚖𝚎 𝚙𝚊𝚝𝚝𝚎𝚛𝚗: {𝚝𝚒𝚝𝚕𝚎}
```
created the expected dated folder structure and meeting notes.