### PR TITLE
Add existing-note search scope so moved notes aren't duplicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To sync more than one Granola account, click **Add Granola account** in settings
 | Template path | `Templates/Granola.md` | Path to your template file |
 | Show ribbon icon | On | Show a sync button in the left sidebar |
 | Skip existing notes | On | Don't overwrite notes you've edited |
+| Existing note search scope | Sync folder only | Where to look for previously synced notes (matched by `granola_id`). Choose "Entire vault" (or "Specific folders") so notes you've moved out of the sync folder aren't re-created as duplicates |
 | Match attendees by email | On | Link attendees to notes with matching email in frontmatter |
 
 ## Usage

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,12 +367,10 @@ export default class GranolaSyncPlugin extends Plugin {
 		// Build map of existing granola_id -> file (shared across all accounts)
 		const existingDocs = new Map<string, TFile>();
 		const files = this.app.vault.getMarkdownFiles();
-		const folderPrefix = folderPath + "/";
-		for (const file of files) {
-			if (!file.path.startsWith(folderPrefix)) continue;
+		for (const file of this.getExistingNoteSearchFiles(files, folderPath)) {
 			const fileCache = this.app.metadataCache.getFileCache(file);
 			const granolaId = fileCache?.frontmatter?.granola_id as string | undefined;
-			if (granolaId) {
+			if (granolaId && !existingDocs.has(granolaId)) {
 				existingDocs.set(granolaId, file);
 			}
 		}
@@ -432,6 +430,34 @@ export default class GranolaSyncPlugin extends Plugin {
 				message += `. ${failedAccounts} account${failedAccounts !== 1 ? "s" : ""} failed — check console.`;
 			}
 			new Notice(message);
+		}
+	}
+
+	/**
+	 * Files to check for previously synced notes, per the configured search
+	 * scope. The sync folder is always included and ordered first so its copy
+	 * wins if the same granola_id exists both there and elsewhere.
+	 */
+	private getExistingNoteSearchFiles(files: TFile[], folderPath: string): TFile[] {
+		const folderPrefix = folderPath + "/";
+		const inSyncFolder = files.filter((f) => f.path.startsWith(folderPrefix));
+
+		switch (this.settings.existingNoteSearchScope) {
+			case "entireVault":
+				return [...inSyncFolder, ...files.filter((f) => !f.path.startsWith(folderPrefix))];
+			case "specificFolders": {
+				const prefixes = this.settings.specificSearchFolders
+					.map((f) => normalizePath(f))
+					.filter((f) => f.length > 0 && f !== "/")
+					.map((f) => f + "/");
+				const elsewhere = files.filter(
+					(f) =>
+						!f.path.startsWith(folderPrefix) && prefixes.some((p) => f.path.startsWith(p))
+				);
+				return [...inSyncFolder, ...elsewhere];
+			}
+			default:
+				return inSyncFolder;
 		}
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,6 +30,14 @@ const SYNC_TIME_RANGE_OPTIONS: Record<SyncTimeRange, string> = {
 	last_30_days: "Last 30 days",
 };
 
+export type ExistingNoteSearchScope = "syncFolder" | "entireVault" | "specificFolders";
+
+const EXISTING_NOTE_SEARCH_SCOPE_OPTIONS: Record<ExistingNoteSearchScope, string> = {
+	syncFolder: "Sync folder only",
+	entireVault: "Entire vault",
+	specificFolders: "Specific folders",
+};
+
 export interface GranolaSyncSettings {
 	folderPath: string;
 	filenamePattern: string;
@@ -40,6 +48,8 @@ export interface GranolaSyncSettings {
 	matchAttendeesByEmail: boolean;
 	syncTimeRange: SyncTimeRange;
 	syncTranscripts: boolean;
+	existingNoteSearchScope: ExistingNoteSearchScope;
+	specificSearchFolders: string[];
 }
 
 export const DEFAULT_SETTINGS: GranolaSyncSettings = {
@@ -52,6 +62,8 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
 	matchAttendeesByEmail: true,
 	syncTimeRange: "last_30_days",
 	syncTranscripts: false,
+	existingNoteSearchScope: "syncFolder",
+	specificSearchFolders: [],
 };
 
 export class GranolaSyncSettingTab extends PluginSettingTab {
@@ -256,6 +268,44 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Existing note search scope")
+			.setDesc(
+				"Where to look for previously synced notes (matched by their Granola meeting ID in frontmatter). Search beyond the sync folder so notes you've moved elsewhere in your vault aren't re-created as duplicates."
+			)
+			.addDropdown((dropdown) => {
+				for (const [value, label] of Object.entries(EXISTING_NOTE_SEARCH_SCOPE_OPTIONS)) {
+					dropdown.addOption(value, label);
+				}
+				dropdown
+					.setValue(this.plugin.settings.existingNoteSearchScope)
+					.onChange(async (value) => {
+						this.plugin.settings.existingNoteSearchScope = value as ExistingNoteSearchScope;
+						await this.plugin.saveSettings();
+						this.display();
+					});
+			});
+
+		if (this.plugin.settings.existingNoteSearchScope === "specificFolders") {
+			new Setting(containerEl)
+				.setName("Folders to search")
+				.setDesc(
+					"Folder paths to search for existing notes, one per line (subfolders included). The sync folder is always searched."
+				)
+				.addTextArea((text) =>
+					text
+						.setPlaceholder("One folder path per line")
+						.setValue(this.plugin.settings.specificSearchFolders.join("\n"))
+						.onChange(async (value) => {
+							this.plugin.settings.specificSearchFolders = value
+								.split("\n")
+								.map((f) => f.trim())
+								.filter((f) => f.length > 0);
+							await this.plugin.saveSettings();
+						})
+				);
+		}
 
 		new Setting(containerEl)
 			.setName("Match attendees by email")


### PR DESCRIPTION
Previously the sync only looked for existing granola_id frontmatter inside the configured sync folder, so moving a meeting note elsewhere in the vault (e.g. a project folder) caused the next sync to re-create it as a duplicate.

Adds an "Existing note search scope" setting with three options:
- Sync folder only (default, unchanged behavior)
- Entire vault
- Specific folders (one path per line; sync folder always included)

The sync folder is searched first so its copy wins if the same granola_id exists in multiple places. Uses the existing metadataCache lookup, so a vault-wide scan stays cheap.

Inspired by the same feature in dannymcc/Granola-to-Obsidian (Granola Sync Plus for Obsidian).