### PR TITLE
Prevent transcript loss when Granola rate-limits requests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,20 @@ import { syncFolderFirst } from "./note-scope";
 import {
 	parseMeetingsResponse,
 	parseTranscriptResponse,
+	isTranscriptErrorResponse,
+	extractStoredTranscript,
 	parseAccountInfo,
 	buildMeetingData,
 	excludeSelf,
 } from "./response-parser";
 import { loadTemplate, applyTemplate, getFolderBasePath, resolveNotePath } from "./template";
+
+const MAX_TRANSCRIPT_FETCHES_PER_ACCOUNT_SYNC = 4;
+const TRANSCRIPT_FETCH_SPACING_MS = 65_000;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
 
 export interface GranolaAccount {
 	id: string;
@@ -603,6 +612,9 @@ export default class GranolaSyncPlugin extends Plugin {
 
 		let created = 0;
 		let updated = 0;
+		let transcriptFetches = 0;
+		let lastTranscriptFetchAt = 0;
+		let transcriptRateLimited = false;
 
 		for (const details of allDetails) {
 			try {
@@ -611,15 +623,47 @@ export default class GranolaSyncPlugin extends Plugin {
 					continue;
 				}
 
-				// Optionally fetch transcript
+				const existingFile = ctx.existingDocs.get(details.id);
+
+				// Reuse a valid stored transcript. Transcript calls are the expensive,
+				// rate-limited part of the API and existing notes do not need to fetch
+				// the same immutable transcript every 15 minutes.
 				let transcript = "";
 				if (this.settings.syncTranscripts) {
-					try {
-						const transcriptResponse = await mcp.getTranscript(details.id);
-						transcript = parseTranscriptResponse(transcriptResponse);
-					} catch (error) {
-						console.error(`Granola: transcript fetch failed for ${details.id}`, error);
+					if (existingFile) {
+						transcript = extractStoredTranscript(await this.app.vault.read(existingFile));
 					}
+
+					if (
+						!transcript &&
+						!transcriptRateLimited &&
+						transcriptFetches < MAX_TRANSCRIPT_FETCHES_PER_ACCOUNT_SYNC
+					) {
+						try {
+							const elapsed = Date.now() - lastTranscriptFetchAt;
+							if (lastTranscriptFetchAt && elapsed < TRANSCRIPT_FETCH_SPACING_MS) {
+								await sleep(TRANSCRIPT_FETCH_SPACING_MS - elapsed);
+							}
+							lastTranscriptFetchAt = Date.now();
+							transcriptFetches++;
+							const transcriptResponse = await mcp.getTranscript(details.id);
+							if (isTranscriptErrorResponse(transcriptResponse)) {
+								transcriptRateLimited = true;
+								throw new Error(`Granola returned a transient transcript error: ${transcriptResponse.trim()}`);
+							}
+							transcript = parseTranscriptResponse(transcriptResponse);
+						} catch (error) {
+							console.error(`Granola: transcript fetch failed for ${details.id}`, error);
+							// Never replace an existing note with an API error or an empty
+							// transcript. A later paced sync will retry it.
+							if (existingFile) continue;
+						}
+					}
+
+					// A rate limit or the per-sync request budget can leave later
+					// meetings without a transcript fetch. Never let those meetings
+					// fall through to a rewrite that removes their stored content.
+					if (!transcript && existingFile) continue;
 				}
 
 				const meetingData = buildMeetingData(details, transcript);
@@ -627,8 +671,6 @@ export default class GranolaSyncPlugin extends Plugin {
 					meetingData.participants = excludeSelf(meetingData.participants, account.email);
 				}
 				const content = applyTemplate(ctx.template, meetingData, ctx.emailToNoteTitle);
-				const existingFile = ctx.existingDocs.get(details.id);
-
 				if (existingFile) {
 					await this.app.vault.modify(existingFile, content);
 					updated++;

--- a/src/response-parser.test.ts
+++ b/src/response-parser.test.ts
@@ -3,6 +3,8 @@ import {
 	parseMeetingsResponse,
 	parseParticipants,
 	parseTranscriptResponse,
+	isTranscriptErrorResponse,
+	extractStoredTranscript,
 	parseAccountInfo,
 	formatTranscriptText,
 	parseGranolaDate,
@@ -244,6 +246,46 @@ describe("parseTranscriptResponse", () => {
 			'{\n  "id": "abc",\n  "title": "A Meeting",\n  "transcript": " Speaker: hello.  Microphone: hi. "\n}',
 		].join("\n");
 		expect(parseTranscriptResponse(response)).toBe("Speaker: hello.  Microphone: hi.");
+	});
+});
+
+describe("isTranscriptErrorResponse", () => {
+	it("recognizes Granola's plain-text rate-limit response", () => {
+		expect(isTranscriptErrorResponse("Rate limit exceeded. Please slow down requests.")).toBe(
+			true,
+		);
+	});
+
+	it("does not reject ordinary transcript text that discusses rate limits", () => {
+		expect(
+			isTranscriptErrorResponse(
+				"Me: The rate limit exceeded our expectations during the test. Them: Good to know.",
+			),
+		).toBe(false);
+	});
+});
+
+describe("extractStoredTranscript", () => {
+	it("extracts the transcript rendered by the default template", () => {
+		expect(
+			extractStoredTranscript(
+				"## Summary\n\nA summary.\n\n## Transcript\n\n**Me:** hello\n\n**Them:** hi\n",
+			),
+		).toBe("**Me:** hello\n\n**Them:** hi");
+	});
+
+	it("unwraps a fenced transcript", () => {
+		expect(extractStoredTranscript("## Transcript\n\n```text\nSpeaker: hello\n```\n")).toBe(
+			"Speaker: hello",
+		);
+	});
+
+	it("treats a stored rate-limit response as missing", () => {
+		expect(
+			extractStoredTranscript(
+				"## Transcript\n\nRate limit exceeded. Please slow down requests.\n",
+			),
+		).toBe("");
 	});
 });
 

--- a/src/response-parser.ts
+++ b/src/response-parser.ts
@@ -246,6 +246,37 @@ export function parseTranscriptResponse(text: string): string {
 	return text.trim();
 }
 
+/**
+ * Granola's MCP endpoint can return a short plain-text error as successful tool
+ * content. Without this guard the error body is indistinguishable from a
+ * legacy plain-text transcript and gets written into the note.
+ */
+export function isTranscriptErrorResponse(text: string): boolean {
+	const normalized = text.trim().replace(/\s+/g, " ");
+	if (!normalized || normalized.length > 500) return false;
+	return /^(?:rate limit exceeded|too many requests|request rate limited|temporarily unavailable|service unavailable)(?:\b|[.:])/i.test(
+		normalized,
+	);
+}
+
+/**
+ * Recover the transcript rendered by the plugin's default template so an
+ * existing note can be refreshed without downloading the same immutable
+ * transcript again. Known API error bodies are treated as missing, allowing a
+ * later paced sync to repair notes written by older plugin versions.
+ */
+export function extractStoredTranscript(content: string): string {
+	const section = content.match(/(?:^|\n)## Transcript\s*\n([\s\S]*?)(?=\n##\s|\n---\s*$|$)/);
+	if (!section) return "";
+
+	let body = section[1].trim();
+	if (body.startsWith("```")) {
+		body = body.replace(/^```[^\n]*\n?/, "").replace(/\n?```\s*$/, "").trim();
+	}
+
+	return isTranscriptErrorResponse(body) ? "" : body;
+}
+
 // Speaker labels are capitalized words followed by a colon: "Microphone:",
 // "Speaker:", a participant's name, or "Me:"/"Them:" in older transcripts.
 const SPEAKER_LABEL = "(\\p{Lu}[\\p{L}'’.-]*(?: \\p{Lu}[\\p{L}'’.-]*){0,3}):";


### PR DESCRIPTION
## Problem

With transcript sync enabled and existing-note updates allowed, every periodic sync downloads every transcript again. Granola can return a short plain-text error such as `Rate limit exceeded. Please slow down requests.` as successful MCP tool content. The parser treats that text as a legacy transcript, so the next note update replaces a previously valid full transcript with the error message.

## Changes

- Detect short transient transcript error responses before parsing or writing them.
- Reuse a valid transcript already rendered under the standard `## Transcript` section.
- Pace missing-transcript requests at 65 seconds and cap each account sync at four requests.
- Stop issuing transcript requests for the rest of the account sync after the first transient error.
- Preserve an existing note whenever its transcript cannot be fetched, including meetings skipped after the rate-limit guard or request budget activates.
- Add coverage for error detection and stored-transcript extraction, including fenced transcript sections.

New notes can still be created without a transcript when the request budget is exhausted; a later paced sync can fill them. Existing notes are never rewritten without their transcript.

## Reproduction

1. Enable transcript sync.
2. Disable Skip existing notes.
3. Use a periodic sync over several meetings.
4. Have `get_meeting_transcript` return the plain-text rate-limit response.
5. Observe that the current release writes that response into the note in place of the full transcript.

## Verification

- `npm run lint`
- `npm test` — 101 passing
- `npm run typecheck`
- `npm run build`